### PR TITLE
Return self in set

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Original - @Gozola. 
+// Original - @Gozola.
 // https://gist.github.com/Gozala/1269991
 // This is a reimplemented version (with a few bug fixes).
 
@@ -17,6 +17,7 @@ function weakMap() {
         },
         'set': function (key, value) {
             privates(key).value = value;
+            return this;
         },
         'has': function(key) {
             return 'value' in privates(key);

--- a/test/weakmap.js
+++ b/test/weakmap.js
@@ -35,6 +35,14 @@ test('weakMap does not work with string keys', function (assert) {
     assert.end()
 })
 
+test('weakMap set returns self', function (assert) {
+    var map = weakMap();
+
+    assert.equal(map.set({}, 'bar'), map);
+
+    assert.end();
+})
+
 test('weakMap has()', function (assert) {
     var map = weakMap()
 


### PR DESCRIPTION
Hi @Raynos!
`set` method should return weakmap instance ([reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/set)), and it does so in native implementation(s).
Here is a fix for that.
Appreciate your work.
Thanks.